### PR TITLE
Add helm chart for running on local cluster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,39 +1,73 @@
 name: 🤓 GH Action 🚧
 
 on:
+  workflow_call:
+    inputs:
+      push_docker_image:
+        type: string  # true or false
+        default: "false"
+    outputs:
+      docker_image_name:
+        description: "Only docker image name"
+        value: ${{ jobs.build_test.outputs.docker_image_name }}
+      docker_image_tag:
+        description: "Only docker image tag"
+        value: ${{ jobs.build_test.outputs.docker_image_tag }}
+      docker_image:
+        description: "docker image with tag"
+        value: ${{ jobs.build_test.outputs.docker_image }}
   pull_request:
-  push:
-    branches:
-      - main
+  # NOTE: For other, they should be run through helm github action ./helm-publish.yml
 
 jobs:
   build_test:
     name: 🚴 Build + Test 🚴  # Match the name below (8398a7/action-slack).
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
+
+    outputs:
+      docker_image_name: ${{ steps.prep.outputs.tagged_image_name }}
+      docker_image_tag: ${{ steps.prep.outputs.tag }}
+      docker_image: ${{ steps.prep.outputs.tagged_image }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@main
 
-      - name: Log in to registry
-        # This is where you will update the personal access token to GITHUB_TOKEN
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        if: ${{ inputs.push_docker_image }}
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🐳 Prepare Docker
         id: prep
+        env:
+          IMAGE_NAME: ghcr.io/${{ github.repository }}
         run: |
-          TAG=$(echo $GITHUB_SHA | head -c7)
-          IMAGE="ghcr.io/ifrcgo/go-risk-module-api"
-          echo "tagged_image=${IMAGE}:${TAG}" >> $GITHUB_OUTPUT
+          BRANCH_NAME=$(echo $GITHUB_REF_NAME | sed 's|:|-|' | tr '[:upper:]' '[:lower:]' | sed 's/_/-/g' | cut -c1-100 | sed 's/-*$//')
+
+          # XXX: Check if there is a slash in the BRANCH_NAME eg: project/add-docker
+          if [[ "$BRANCH_NAME" == *"/"* ]]; then
+              # XXX: Change the docker image package to -alpha
+              IMAGE_NAME="$IMAGE_NAME-alpha"
+              TAG="$(echo "$BRANCH_NAME" | sed 's|/|-|g').$(echo $GITHUB_SHA | head -c7)"
+          else
+              TAG="$BRANCH_NAME.$(echo $GITHUB_SHA | head -c7)"
+          fi
+
+          IMAGE_NAME=$(echo $IMAGE_NAME | tr '[:upper:]' '[:lower:]')
+          echo "tagged_image_name=${IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
+          echo "tagged_image=${IMAGE_NAME}:${TAG}" >> $GITHUB_OUTPUT
+          echo "::notice::Tagged docker image: ${IMAGE_NAME}:${TAG}"
+
       - name: 🐳 Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@v3
 
       - name: 🐳 Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.ref }}
@@ -42,12 +76,13 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: 🐳 Docker build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           builder: ${{ steps.buildx.outputs.name }}
           file: Dockerfile
           load: true
+          push: false
           tags: ${{ steps.prep.outputs.tagged_image }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
@@ -71,17 +106,33 @@ jobs:
           }
 
       - name: 🐳 Docker push
-        if: github.event_name == 'push'
-        uses: docker/build-push-action@v4
+        if: ${{ inputs.push_docker_image }}
+        uses: docker/build-push-action@v6
         with:
           tags: ${{ steps.prep.outputs.tagged_image }}
           push: true
 
-        # Temp fix
-        # https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#github-cache
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
+      # Temp fix
+      # https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#github-cache
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
       - name: 🐳 Move docker cache (🧙 Hack fix)
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+  validate_helm:
+    name: 🚴 Validate Helm 🚴
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@main
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: 🐳 Helm lint
+        run: helm lint ./helm --values ./helm/values-test.yaml
+
+      - name: 🐳 Helm template
+        run: helm template ./helm --values ./helm/values-test.yaml

--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -1,0 +1,76 @@
+name: Builds and pushes Docker Images and Helm charts to Github Registry
+
+on:
+  push:
+    branches:
+      - develop
+      - project/*
+    # XXX: To add tags: Update the -alpha logic
+
+permissions:
+  packages: write
+
+jobs:
+  ci:
+    name: CI
+    uses: ./.github/workflows/ci.yml
+    with:
+      push_docker_image: true
+
+  build:
+    name: Publish Helm
+    needs: ci
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Install Helm
+      uses: azure/setup-helm@v3
+
+    - name: Tag docker image in Helm Chart values.yaml
+      env:
+        IMAGE_NAME: ${{ needs.ci.outputs.docker_image_name }}
+        IMAGE_TAG: ${{ needs.ci.outputs.docker_image_tag }}
+      run: |
+        # Update values.yaml with latest docker image
+        sed -i "s|SET-BY-CICD-IMAGE|$IMAGE_NAME|" helm/values.yaml
+        sed -i "s/SET-BY-CICD-TAG/$IMAGE_TAG/" helm/values.yaml
+
+    - name: Package Helm Chart
+      id: set-variables
+      run: |
+        # XXX: Check if there is a slash in the BRANCH_NAME eg: project/add-docker
+        if [[ "$GITHUB_REF_NAME" == *"/"* ]]; then
+            # XXX: Change the helm chart to <chart-name>-alpha
+            sed -i 's/^name: \(.*\)/name: \1-alpha/' helm/Chart.yaml
+        fi
+
+        SHA_SHORT=$(git rev-parse --short HEAD)
+        sed -i "s/SET-BY-CICD/$SHA_SHORT/g" helm/Chart.yaml
+        helm package ./helm -d .helm-charts
+
+    - name: Push Helm Chart
+      env:
+        IMAGE: ${{ needs.ci.outputs.docker_image }}
+        OCI_REPO: oci://ghcr.io/${{ github.repository }}
+      run: |
+        OCI_REPO=$(echo $OCI_REPO | tr '[:upper:]' '[:lower:]')
+        PACKAGE_FILE=$(ls .helm-charts/*.tgz | head -n 1)
+        echo "# Helm Chart" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "Tagged Image: **$IMAGE**" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "Helm push output" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo '```bash' >> $GITHUB_STEP_SUMMARY
+        helm push "$PACKAGE_FILE" $OCI_REPO >> $GITHUB_STEP_SUMMARY
+        echo '```' >> $GITHUB_STEP_SUMMARY

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM python:3.8-slim-buster
 
 LABEL maintainer="IFRC"
+LABEL org.opencontainers.image.source="https://github.com/IFRCGo/go-risk-module-api"
 
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONUNBUFFERED=1
 
 WORKDIR /code
 

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -11,7 +11,7 @@
     @notStatic {
         not path /static/* /media/*
     }
-    reverse_proxy @notStatic server:9007 {
+    reverse_proxy @notStatic server:80 {
         header_up X-Forwarded-Proto https
     }
     file_server

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: ifrcgo-risk-module-helm
+description: "Helm Chart to deploy the IFRC GO Risk Module Infrastructure"
+type: application
+version: 0.0.1-SET-BY-CICD
+sources:
+  - https://github.com/IFRCGo/go-risk-module-api

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/*
+    Expand the name of the chart.
+*/}}
+{{- define "ifrcgo-risk-module.name" -}}
+    {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+    Create a default fully qualified app name.
+    We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+    If release name contains chart name it will be used as a full name.
+    https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
+*/}}
+{{- define "ifrcgo-risk-module.fullname" -}}
+    {{- if .Values.fullnameOverride -}}
+        {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+    {{- else -}}
+        {{- $name := default .Chart.Name .Values.nameOverride -}}
+        {{- if contains $name .Release.Name -}}
+            {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+        {{- else -}}
+            {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+
+{{/*
+    Create chart name and version as used by the chart label.
+*/}}
+{{- define "ifrcgo-risk-module.chart" -}}
+    {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/helm/templates/api/deployment.yaml
+++ b/helm/templates/api/deployment.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.api.enabled }}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "ifrcgo-risk-module.fullname" . }}-api
+  labels:
+    component: api-deployment
+    environment: {{ .Values.environment }}
+    release: {{ .Release.Name }}
+    # XXX: Add global lables?
+spec:
+  replicas: {{ .Values.api.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "ifrcgo-risk-module.name" . }}
+      release: {{ .Release.Name }}
+      run: {{ .Release.Name }}-api
+  template:
+    metadata:
+      annotations:
+        checksum/secret: {{ include (print .Template.BasePath "/config/secret.yaml") . | sha256sum }}
+        checksum/configmap: {{ include (print .Template.BasePath "/config/configmap.yaml") . | sha256sum }}
+      labels:
+        app: {{ template "ifrcgo-risk-module.name" . }}
+        release: {{ .Release.Name }}
+        run: {{ .Release.Name }}-api
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}-api
+          image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
+          command: ["bash", "/code/scripts/run_prod.sh"]
+          ports:
+            - name: http
+              containerPort: {{ .Values.api.containerPort }}
+              protocol: TCP
+          # livenessProbe: # FIXME: Fix Liveness Probe
+          #   httpGet:
+          #     path: /api/  # Add custom health-check for pod instead of whole system
+          #     port: \{\{ .Values.api.containerPort }}
+          #   initialDelaySeconds: 10180  # TODO:?
+          #   periodSeconds: 5  # TODO:?
+          resources:
+            requests:
+              cpu: {{ .Values.api.resources.requests.cpu }}
+              memory: {{ .Values.api.resources.requests.memory }}
+            limits:
+              cpu: {{ .Values.api.resources.limits.cpu }}
+              memory: {{ .Values.api.resources.limits.memory }}
+          envFrom:
+            - secretRef:
+                name: {{ template "ifrcgo-risk-module.fullname" . }}-api-secret
+            - configMapRef:
+                name: {{ template "ifrcgo-risk-module.fullname" . }}-api-configmap
+
+{{- end }}

--- a/helm/templates/api/ingress.yaml
+++ b/helm/templates/api/ingress.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.ingress.enabled }}
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ template "ifrcgo-risk-module.fullname" . }}-ingress
+  labels:
+    app: {{ template "ifrcgo-risk-module.name" . }}
+    component: api-service
+    environment: {{ .Values.environment }}
+    release: {{ .Release.Name }}
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: {{ required "ingress.host" .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ template "ifrcgo-risk-module.fullname" . }}-api-svc
+                port:
+                  number: 80
+
+{{- end }}

--- a/helm/templates/api/service.yaml
+++ b/helm/templates/api/service.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.api.enabled -}}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "ifrcgo-risk-module.fullname" . }}-api-svc
+  labels:
+    app: {{ template "ifrcgo-risk-module.name" . }}
+    component: api-service
+    environment: {{ .Values.environment }}
+    release: {{ .Release.Name }}
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ template "ifrcgo-risk-module.name" . }}
+    release: {{ .Release.Name }}
+    run: {{ .Release.Name }}-api
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: {{ .Values.api.containerPort }}
+      nodePort: null
+
+{{- end }}

--- a/helm/templates/config/configmap.yaml
+++ b/helm/templates/config/configmap.yaml
@@ -1,0 +1,30 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ template "ifrcgo-risk-module.fullname" . }}-api-configmap
+  labels:
+    component: api-deployment
+    environment: {{ .Values.environment }}
+    release: {{ .Release.Name }}
+data:
+  # Application info
+  RISK_RELEASE: {{ .Values.image.tag | quote }}
+  RISK_ENVIRONMENT: {{ .Values.environment | quote | upper }}
+  RISK_API_FQDN: {{ required "env.RISK_API_FQDN" .Values.env.RISK_API_FQDN | quote }}
+  # Django configs
+  DJANGO_DEBUG: {{ .Values.env.DJANGO_DEBUG | quote }}
+  DJANGO_ALLOWED_HOSTS: {{ .Values.env.DJANGO_ALLOWED_HOSTS | quote }}
+  TIME_ZONE: {{ .Values.env.TIME_ZONE | quote }}
+  # Redis
+  {{- if .Values.redis.enabled }}
+  CELERY_REDIS_URL: "redis://{{ template "ifrcgo-risk-module.fullname" . }}-redis:6379/0"
+  CACHE_REDIS_URL: "redis://{{ template "ifrcgo-risk-module.fullname" . }}-redis:6379/1"
+  {{- else }}
+  CELERY_REDIS_URL: {{ required "env.CELERY_REDIS_URL" .Values.env.CELERY_REDIS_URL | quote }}
+  CACHE_REDIS_URL: {{ required "env.CACHE_REDIS_URL" .Values.env.CACHE_REDIS_URL | quote }}
+  {{- end }}
+  # Sentry
+  SENTRY_TRACE_SAMPLE_RATE: {{ .Values.env.SENTRY_TRACE_SAMPLE_RATE | quote }}
+  SENTRY_PROFILE_SAMPLE_RATE: {{ .Values.env.SENTRY_PROFILE_SAMPLE_RATE | quote }}
+  # Logging
+  APPS_LOGGING_LEVEL: {{ .Values.env.APPS_LOGGING_LEVEL | quote }}

--- a/helm/templates/config/secret.yaml
+++ b/helm/templates/config/secret.yaml
@@ -1,0 +1,28 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ template "ifrcgo-risk-module.fullname" . }}-api-secret
+  labels:
+    component: api-deployment
+    environment: {{ .Values.environment }}
+    release: {{ .Release.Name }}
+type: Opaque
+stringData:
+  DJANGO_SECRET_KEY: {{ required "secrets.DJANGO_SECRET_KEY" .Values.secrets.DJANGO_SECRET_KEY | quote }}
+  # Database
+  DATABASE_NAME: {{ required "secrets.DATABASE_NAME" .Values.secrets.DATABASE_NAME | quote }}
+  DATABASE_USER: {{ required "secrets.DATABASE_USER" .Values.secrets.DATABASE_USER | quote }}
+  DATABASE_PASSWORD: {{ required "secrets.DATABASE_PASSWORD" .Values.secrets.DATABASE_PASSWORD | quote }}
+  DATABASE_HOST: {{ required "secrets.DATABASE_HOST" .Values.secrets.DATABASE_HOST | quote }}
+  DATABASE_PORT: {{ required "secrets.DATABASE_PORT" .Values.secrets.DATABASE_PORT | quote }}
+  # Sentry
+  SENTRY_DSN: {{ required "secrets.SENTRY_DSN" .Values.secrets.SENTRY_DSN | quote }}
+  # PDC
+  PDC_USERNAME: {{ required "secrets.PDC_USERNAME" .Values.secrets.PDC_USERNAME | quote }}
+  PDC_PASSWORD: {{ required "secrets.PDC_PASSWORD" .Values.secrets.PDC_PASSWORD | quote }}
+  PDC_ACCESS_TOKEN: {{ required "secrets.PDC_ACCESS_TOKEN" .Values.secrets.PDC_ACCESS_TOKEN | quote }}
+  # Meteoswiss
+  METEOSWISS_S3_ENDPOINT_URL: {{ required "secrets.METEOSWISS_S3_ENDPOINT_URL" .Values.secrets.METEOSWISS_S3_ENDPOINT_URL | quote }}
+  METEOSWISS_S3_BUCKET: {{ required "secrets.METEOSWISS_S3_BUCKET" .Values.secrets.METEOSWISS_S3_BUCKET | quote }}
+  METEOSWISS_S3_ACCESS_KEY: {{ required "secrets.METEOSWISS_S3_ACCESS_KEY" .Values.secrets.METEOSWISS_S3_ACCESS_KEY | quote }}
+  METEOSWISS_S3_SECRET_KEY: {{ required "secrets.METEOSWISS_S3_SECRET_KEY" .Values.secrets.METEOSWISS_S3_SECRET_KEY | quote }}

--- a/helm/templates/cronjobs/jobs.yaml
+++ b/helm/templates/cronjobs/jobs.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.worker.enabled }}
+
+{{- range $i, $job := .Values.worker.cronjobs }}
+
+{{- if $job.enabled }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: "{{ template "ifrcgo-risk-module.fullname" $ }}-{{ $i | nospace | lower | replace "_" "-" }}"
+  labels:
+    component: api-jobs
+    environment: {{ $.Values.environment }}
+    release: {{ $.Release.Name }}
+spec:
+  schedule: {{ $job.schedule | quote }}
+  concurrencyPolicy: "Forbid"
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: {{ default 7200 $job.timeLimit }}  # 2 hours default TODO: Lower this
+      template:
+        spec:
+          restartPolicy: "Never"
+          containers:
+            - name: "{{ template "ifrcgo-risk-module.fullname" $ }}-{{ $i | nospace | lower | replace "_" "-" }}"
+              image: "{{ $.Values.image.name }}:{{ $.Values.image.tag }}"
+              command: ["./manage.py", "{{ $i }}"]
+              resources:
+                requests:
+                  cpu: {{ default $.Values.worker.defaultResources.requests.cpu $job.requestsCpu }}
+                  memory: {{ default $.Values.worker.defaultResources.requests.memory $job.requestsMemory }}
+                limits:
+                  cpu: {{ default $.Values.worker.defaultResources.limits.cpu $job.limitsCpu }}
+                  memory: {{ default $.Values.worker.defaultResources.limits.memory $job.limitsMemory }}
+              envFrom:
+                - secretRef:
+                    name: {{ template "ifrcgo-risk-module.fullname" $ }}-api-secret
+                - configMapRef:
+                    name: {{ template "ifrcgo-risk-module.fullname" $ }}-api-configmap
+
+{{- end }}
+
+{{- end }}
+
+{{- end }}

--- a/helm/templates/redis/deployment.yaml
+++ b/helm/templates/redis/deployment.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.redis.enabled }}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "ifrcgo-risk-module.fullname" . }}-redis
+  labels:
+    component: redis-deployment
+    environment: {{ .Values.environment }}
+    release: {{ .Release.Name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "ifrcgo-risk-module.name" . }}
+      release: {{ .Release.Name }}
+      run: {{ .Release.Name }}-redis
+  template:
+    metadata:
+      labels:
+        app: {{ template "ifrcgo-risk-module.name" . }}
+        release: {{ .Release.Name }}
+        run: {{ .Release.Name }}-redis
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}-redis
+          image: "redis:latest"
+          ports:
+            - name: http
+              containerPort: 6379
+              protocol: TCP
+          resources:
+            requests:
+              cpu: {{ .Values.redis.resources.requests.cpu }}
+              memory: {{ .Values.redis.resources.requests.memory }}
+            limits:
+              cpu: {{ .Values.redis.resources.limits.cpu }}
+              memory: {{ .Values.redis.resources.limits.memory }}
+
+{{- end }}

--- a/helm/values-test.yaml
+++ b/helm/values-test.yaml
@@ -1,0 +1,44 @@
+environment: test
+
+fullnameOverride: ifrcgo-risk
+
+image:
+  name: ghcr.io/ifrcgo/go-risk-module-api
+  tag: test
+
+ingress:
+  enabled: true
+  host: go-risk-test.ifrc.org
+
+env:
+  # Application info
+  RISK_API_FQDN: go-risk-test.ifrc.org
+  # Django configs
+  DJANGO_DEBUG: false
+  DJANGO_ALLOWED_HOSTS: "*"
+  TIME_ZONE: "UTC"
+  # Sentry
+  SENTRY_TRACE_SAMPLE_RATE: "0.2"
+  SENTRY_PROFILE_SAMPLE_RATE: "0.2"
+  # Logging
+  APPS_LOGGING_LEVEL: "WARNING"
+
+secrets:
+  DJANGO_SECRET_KEY: test
+  # Database
+  DATABASE_NAME: test
+  DATABASE_USER: test
+  DATABASE_PASSWORD: test
+  DATABASE_HOST: test
+  DATABASE_PORT: 5432
+  # Sentry
+  SENTRY_DSN: "https://test.com/test"
+  # PDC
+  PDC_USERNAME: test
+  PDC_PASSWORD: test
+  PDC_ACCESS_TOKEN: test
+  # Meteoswiss
+  METEOSWISS_S3_ENDPOINT_URL: test
+  METEOSWISS_S3_BUCKET: test
+  METEOSWISS_S3_ACCESS_KEY: test
+  METEOSWISS_S3_SECRET_KEY: test

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,124 @@
+environment: prod
+
+image:
+  name: SET-BY-CICD-IMAGE
+  tag: SET-BY-CICD-TAG
+
+ingress:
+  enabled: false
+  host:
+
+redis:
+  enabled: true
+  resources:
+    requests:
+      cpu: "0.5"
+      memory: 100Mi
+    limits:
+      cpu: "1"
+      memory: 200Mi
+
+api:
+  enabled: true
+  replicaCount: 1
+  containerPort: 80
+  resources:
+    requests:
+      cpu: "2"
+      memory: 0.5Gi
+    limits:
+      cpu: "2"
+      memory: 1Gi
+
+env:
+  # Application info
+  # RISK_ENVIRONMENT: .environment is used
+  RISK_API_FQDN:
+  # Django configs
+  DJANGO_DEBUG: false
+  DJANGO_ALLOWED_HOSTS: "*"
+  TIME_ZONE: "UTC"
+  # Sentry
+  SENTRY_TRACE_SAMPLE_RATE: "0.2"
+  SENTRY_PROFILE_SAMPLE_RATE: "0.2"
+  # Logging
+  APPS_LOGGING_LEVEL: "WARNING"
+
+secrets:
+  DJANGO_SECRET_KEY:
+  # Database
+  DATABASE_NAME:
+  DATABASE_USER:
+  DATABASE_PASSWORD:
+  DATABASE_HOST:
+  DATABASE_PORT: 5432
+  # Sentry
+  SENTRY_DSN: ""
+  # PDC
+  PDC_USERNAME:
+  PDC_PASSWORD:
+  PDC_ACCESS_TOKEN:
+  # Meteoswiss
+  METEOSWISS_S3_ENDPOINT_URL:
+  METEOSWISS_S3_BUCKET:
+  METEOSWISS_S3_ACCESS_KEY:
+  METEOSWISS_S3_SECRET_KEY:
+
+
+worker:
+  enabled: true
+  defaultResources:
+    requests:
+      cpu: "1"
+      memory: 1Gi
+    limits:
+      cpu: "1"
+      memory: 2Gi
+  # NOTE: Application level configuration
+  cronjobs:
+    "import_earthquake_data":
+      schedule: "0 0 * * *"
+      enabled: true
+      # timeLimit: 7200
+    "create_pdc_data":
+      schedule: "0 */2 * * *"
+      enabled: true
+    "create_pdc_daily":
+      schedule: "0 5 * * *"
+      enabled: true
+    "create_pdc_displacement":
+      schedule: "0 */3 * * *"
+      enabled: true
+    "create_pdc_polygon":
+      schedule: "0 */6 * * *"
+      enabled: true
+    "create_pdc_intensity":
+      schedule: "0 */7 * * *"
+      enabled: true
+    "check_pdc_status":
+      schedule: "0 1 * * *"
+      enabled: true
+    "create_hazard_information":
+      schedule: "0 0 2 * *"
+      enabled: true
+    "create_adam_exposure":
+      schedule: "0 */4 * * *"
+      enabled: true
+    "update_adam_cyclone":
+      schedule: "0 */4 * * *"
+      enabled: true
+    "update_adam_alert_level":
+      schedule: "0 */4 * * *"
+      enabled: true
+    "import_gdacs_data":
+      schedule: "0 */4 * * *"
+      enabled: true
+    "pull_meteoswiss":
+      schedule: "0 */4 * * *"
+      enabled: true
+    "pull_meteoswiss_geo":
+      schedule: "0 */4 * * *"
+      enabled: true
+    "meteoswiss_agg":
+      schedule: "0 */4 * * *"
+      enabled: true

--- a/risk_module/settings.py
+++ b/risk_module/settings.py
@@ -22,6 +22,7 @@ from risk_module import sentry
 env = environ.Env(
     # Application info
     RISK_ENVIRONMENT=str,
+    RISK_RELEASE=(str, None),
     RISK_API_FQDN=str,
     # Django configs
     DJANGO_DEBUG=(bool, False),
@@ -367,6 +368,7 @@ SENTRY_DSN = env("SENTRY_DSN")
 SENTRY_TRACE_SAMPLE_RATE = env("SENTRY_TRACE_SAMPLE_RATE")
 SENTRY_PROFILE_SAMPLE_RATE = env("SENTRY_PROFILE_SAMPLE_RATE")
 RISK_ENVIRONMENT = env("RISK_ENVIRONMENT")
+RISK_RELEASE = env("RISK_RELEASE") or sentry.fetch_git_sha(BASE_DIR)
 RISK_API_FQDN = env("RISK_API_FQDN")
 
 SENTRY_CONFIG = {
@@ -374,7 +376,7 @@ SENTRY_CONFIG = {
     "send_default_pii": True,
     "traces_sample_rate": SENTRY_TRACE_SAMPLE_RATE,
     "profiles_sample_rate": SENTRY_PROFILE_SAMPLE_RATE,
-    "release": sentry.fetch_git_sha(BASE_DIR),
+    "release": RISK_RELEASE,
     "environment": RISK_ENVIRONMENT,
     "debug": DEBUG,
     "tags": {

--- a/scripts/run_prod.sh
+++ b/scripts/run_prod.sh
@@ -3,4 +3,4 @@
 python manage.py collectstatic --noinput &
 python manage.py migrate --noinput
 
-gunicorn risk_module.wsgi:application --bind 0.0.0.0:9007
+gunicorn risk_module.wsgi:application --bind 0.0.0.0:80


### PR DESCRIPTION
Addresses
- Helm chart for local k8s cluster

## Changes

* Add helm chart
* Update GitHub action to push docker-images and helm charts
* Add basic helm lint/template check
* Push docker image and helm chart to separate package for `project/x` branches
  - Which will be used by alpha instances
  - Can be easily cleaned-up in future without effecting the staging/prod packages
  - Image: https://github.com/IFRCGo/go-risk-module-api/pkgs/container/go-risk-module-api-alpha
  - Charts: https://github.com/IFRCGo/go-risk-module-api/pkgs/container/go-risk-module-api%2Fifrcgo-risk-module-helm-alpha

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations