### PR TITLE
chore(chart): update bitnami images to legacy

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -6,6 +6,10 @@ image:
 
 imagePullSecrets: []
 
+global:
+  security:
+    allowInsecureImage: true
+
 ingress:
   enabled: false
   className: webapprouting.kubernetes.azure.com
@@ -17,6 +21,8 @@ ingress:
 # For production use azure postgres server and provide credentials using azure keyvault
 postgresql:
   enabled: false
+  image:
+    repository: bitnamilegacy/postgresql
   fullnameOverride: ifrcgo-risk-module-postgresql
   architecture: standalone
   auth:
@@ -32,6 +38,8 @@ postgresql:
 
 redis:
   enabled: false
+  image:
+    repository: bitnamilegacy/redis
   architecture: standalone
   fullnameOverride: ifrcgo-risk-module-redis
   auth:


### PR DESCRIPTION
## Changes

* Updated bitnami images of postgresql and redis
* Added global security rule to allow insecure images 

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [x] permission checks (tests here too)
- [x] translations
